### PR TITLE
Graphics acceleration by default

### DIFF
--- a/io.gdevs.GDLauncher.yml
+++ b/io.gdevs.GDLauncher.yml
@@ -14,6 +14,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --device=all   # controller support
+  - --device=dri  # graphics acceleration
   - --socket=pulseaudio
   - --share=network
   - --env=CHROME_WRAPPER=zypak-wrapper


### PR DESCRIPTION
Without this option the launcher will not work as intended, mod packs will be unable to launch.

* Tested on NVIDIA 1070