### PR TITLE
Change screenshot image link

### DIFF
--- a/io.gdevs.GDLauncher.metainfo.xml
+++ b/io.gdevs.GDLauncher.metainfo.xml
@@ -89,7 +89,7 @@
   <launchable type="desktop-id">io.gdevs.GDLauncher.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://camo.githubusercontent.com/31a463e96f103c0cbaf4630651ff331125849720b074601617bf12e74779cd5b/68747470733a2f2f67646576732e696f2f73686f77636173652e6a7067</image>
+      <image>https://dl.flathub.org/repo/screenshots/io.gdevs.GDLauncher-stable/752x423/io.gdevs.GDLauncher-af643538ffba59fddd179a19f7aeac8f.png</image>
     </screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
Points to FlatHub's hosted screenshot - maybe not the best idea but maybe ok for temporary fix ?