### PR TITLE
Remove java to allow 1.30 to run

### DIFF
--- a/io.gdevs.GDLauncher.yml
+++ b/io.gdevs.GDLauncher.yml
@@ -1,11 +1,9 @@
 app-id: io.gdevs.GDLauncher
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk
 command: gd.sh
 build-options:
   env:
@@ -19,10 +17,6 @@ finish-args:
   - --env=CHROME_WRAPPER=zypak-wrapper
   - --filesystem=xdg-download   # downloaded/export resource packs etc.
 modules:
-  - name: openjdk
-    buildsystem: simple
-    build-commands:
-      - /usr/lib/sdk/openjdk/install.sh
   - name: gdlauncher
     buildsystem: simple
     build-commands:
@@ -35,8 +29,8 @@ modules:
       - install -D gd.sh /app/bin
     sources:
       - type: file
-        url: https://github.com/gorilla-devs/GDLauncher/releases/download/v1.1.29/GDLauncher-linux-setup.AppImage
-        sha256: 84ac89e6ffbed0f182fe758465d3ac729939858e68a09354b8c3e62ca0a027af
+        url: https://github.com/gorilla-devs/GDLauncher/releases/download/v1.1.30/GDLauncher-linux-setup.AppImage
+        sha256: e1c5d3ddec61a0c00aea05b70a9c752fb726f579b414af75da019c4722d83f03
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gorilla-devs/GDLauncher/releases/latest


### PR DESCRIPTION
Now that GDLauncher consistently releases with the latest Java, this probably is not needed anymore, anyway. Sorry for all the trouble.