### PR TITLE
Mark GDLauncher as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
> GDLauncher has been rewritten from the ground up in a more efficient and reliable tech stack, and the new version, "Carbon" has already reached and surpassed feature-parity. We are now working on polishing the experience and adding new features, and while this version will still be available for download, it will no longer be maintained. Due to the very high number of game-breaking bugs recently reported, we recommend you to switch to the new GDLauncher Carbon as soon as possible.

Source: https://github.com/gorilla-devs/GDLauncher/